### PR TITLE
Pull All Performance Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # `prism`
-A node CLI tool to send Google Lighthouse metrics to Datadog.  
+A node CLI tool to send Google Lighthouse metrics to Datadog. 
 
 ## Setup
 Create a `.env` file with the following format:
@@ -28,4 +28,53 @@ Examples:
     node index.js -u https://wuphf.com/ -a wuphf -t tagA:value -t tagB:value
 ```
 
+## What's collected and sent to Datadog?
+
+### Scores
+```javascript
+performance
+accessibility
+best-practices
+seo
+pwa
+```
+
+### Performance Metrics
+```javascript
+firstContentfulPaint
+firstMeaningfulPaint
+firstCPUIdle
+interactive
+speedIndex
+estimatedInputLatency
+totalBlockingTime
+observedNavigationStart
+observedNavigationStartTs
+observedFirstPaint
+observedFirstPaintTs
+observedFirstContentfulPaint
+observedFirstContentfulPaintTs
+observedFirstMeaningfulPaint
+observedFirstMeaningfulPaintTs
+observedLargestContentfulPaint
+observedLargestContentfulPaintTs
+observedTraceEnd
+observedTraceEndTs
+observedLoad
+observedLoadTs
+observedDomContentLoaded
+observedDomContentLoadedTs
+observedFirstVisualChange
+observedFirstVisualChangeTs
+observedLastVisualChange
+observedLastVisualChangeTs
+observedSpeedIndex
+observedSpeedIndexTs
+maxPotentialFid
+timeToFirstByte
+bootupTime
+unminifiedJavascript
+```
+
 *Note:* Reference `example-report.json` for help navigating the data structure that lighthouse uses for generated reports.
+

--- a/datadog.js
+++ b/datadog.js
@@ -15,9 +15,11 @@ const generateMetricsPayload = (app, lhMetrics, tags = []) => {
 };
 
 const sendMetricsToDatadog = async (payload) => {
+  // Only send metrics with values
+  const metricsWithValues = payload.filter((data) => Boolean(data.points[1]));
   return new Promise((resolve, reject) => {
     try {
-      dapi.metric.send_all(payload, (resp) => resolve(resp));
+      dapi.metric.send_all(metricsWithValues, (resp) => resolve(resp));
     } catch (error) {
       reject(error);
     }

--- a/datadog.js
+++ b/datadog.js
@@ -16,7 +16,7 @@ const generateMetricsPayload = (app, lhMetrics, tags = []) => {
 
 const sendMetricsToDatadog = async (payload) => {
   // Only send metrics with values
-  const metricsWithValues = payload.filter((data) => Boolean(data.points[1]));
+  const metricsWithValues = payload.filter((data) => ![undefined, null].includes(data.points[1]));
   return new Promise((resolve, reject) => {
     try {
       dapi.metric.send_all(metricsWithValues, (resp) => resolve(resp));

--- a/lighthouse.js
+++ b/lighthouse.js
@@ -35,8 +35,11 @@ const runLighthouse = async (url, chrome) => {
   };
   const results = await lighthouse(url, options);
 
-  const baseMetricObj = results.lhr.audits.metrics.details.items[0];
-  const baseMetrics = Object.entries(baseMetricObj).map(([name, value]) => ({name, value}));
+  let baseMetrics = [];
+  if (results.lhr.audits.metrics.details) {
+    const baseMetricObj = results.lhr.audits.metrics.details.items[0];
+    baseMetrics = Object.entries(baseMetricObj).map(([name, value]) => ({name, value}));
+  }
 
   const additionalMetrics = additionalAuditKeys.map((key) => {
     const {id, numericValue} = results.lhr.audits[key];


### PR DESCRIPTION
Some refactoring to support more metric fields and extra README documentation.

Instead of selectively defining which metrics we pull, this PR refactors some of the logic to pull all fields from the `metrics` audit key with the option to define some additional metrics that do not exist in that batch.

Note: Metrics with undefined/null values will no longer be sent to datadog but will still appear in the `--dry-run` output.

<img width="934" alt="Screen Shot 2020-07-28 at 11 11 45 AM" src="https://user-images.githubusercontent.com/4543530/88684758-2e2b2100-d0c3-11ea-97c6-159a23bf7890.png">
